### PR TITLE
一点小小的贡献 | a minute contribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ Thumbs.db
 *.rc
 /.qmake.cache
 /.qmake.stash
+compile_commands.json
 
 # qtcreator generated files
 *.pro.user*
@@ -93,4 +94,3 @@ CMakeSettings.json
 # --------
 *.dll
 *.exe
-

--- a/src/SARibbon.h
+++ b/src/SARibbon.h
@@ -285,16 +285,16 @@ public:
 	void enableNoneColorAction(bool on = true);
 	// 获取None Color Action,注意，enableNoneColorAction(true),之后才不是nullptr
 	QAction* noneColorAction() const;
-public slots:
+public Q_SLOTS:
 	// 这是一个辅助槽函数，为了让用户自定义的其他action也能关联menu，可以调用此槽函数，实现selectedColor信号以及menu的隐藏
 	void emitSelectedColor(const QColor& c);
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief 选择了颜色触发的信号
 	 * @param c
 	 */
 	void selectedColor(const QColor& c);
-private slots:
+private Q_SLOTS:
 	void onCustomColorActionTriggered(bool on);
 	void onNoneColorActionTriggered(bool on);
 
@@ -371,13 +371,13 @@ public:
 	void setRowMinimumHeight(int row, int minSize);
 	// 让颜色块左对齐
 	void setHorizontalSpacerToRight(bool on = true);
-private slots:
+private Q_SLOTS:
 	void onButtonClicked(QAbstractButton* btn);
 	void onButtonPressed(QAbstractButton* btn);
 	void onButtonReleased(QAbstractButton* btn);
 	void onButtonToggled(QAbstractButton* btn, bool on);
 
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief 对于check模式，check的颜色触发的信号
 	 * @param c
@@ -433,13 +433,13 @@ public:
 	// 设置颜色是否是checkable
 	void setColorCheckable(bool on = true);
 	bool isColorCheckable() const;
-private slots:
+private Q_SLOTS:
 	void onMainColorClicked(const QColor& c);
 	void onPaletteColorClicked(const QColor& c);
 
 private:
 	void init();
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief 对于check模式，check的颜色触发的信号
 	 * @param c
@@ -526,7 +526,7 @@ public:
 	SAColorMenu* colorMenu() const;
 	// 建立标准的颜色菜单
 	SAColorMenu* createColorMenu();
-public slots:
+public Q_SLOTS:
 	// 设置颜色,会发射colorChanged信号
 	void setColor(const QColor& c);
 
@@ -542,9 +542,9 @@ protected:
 	virtual void paintEvent(QPaintEvent* e) Q_DECL_OVERRIDE;
 	virtual void resizeEvent(QResizeEvent* e) Q_DECL_OVERRIDE;
 	virtual QSize sizeHint() const Q_DECL_OVERRIDE;
-private slots:
+private Q_SLOTS:
 	void onButtonClicked(bool checked = false);
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief 颜色被点击的响应
 	 * @param color
@@ -714,7 +714,7 @@ public:
 protected:
 	virtual void resizeEvent(QResizeEvent* e) Q_DECL_OVERRIDE;
 
-protected slots:
+protected Q_SLOTS:
 	Q_SLOT void closeWindow();
 	Q_SLOT void minimizeWindow();
 	Q_SLOT void maximizeWindow();
@@ -863,12 +863,12 @@ public:
 	ColorStyle colorStyle() const;
 	// 建立标准的颜色菜单
 	SAColorMenu* setupStandardColorMenu();
-public slots:
+public Q_SLOTS:
 	// 设置颜色,会发射colorChanged信号
 	void setColor(const QColor& c);
-private slots:
+private Q_SLOTS:
 	void onButtonClicked(bool checked = false);
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief 颜色被点击的响应
 	 * @param color
@@ -1042,14 +1042,14 @@ public:
 	// 清除
 	void clear();
 
-signals:
+Q_SIGNALS:
 
 	/**
 	 * @brief 标签变化触发的信号，变化包括新增和删除
 	 */
 	void actionTagChanged(int tag, bool isdelete);
 
-private slots:
+private Q_SLOTS:
 	void onActionDestroyed(QObject* o);
 	void onCategoryTitleChanged(const QString& title);
 
@@ -1079,7 +1079,7 @@ public:
 	QAction* indexToAction(QModelIndex index) const;
 	void search(const QString& text);
 
-private slots:
+private Q_SLOTS:
 	void onActionTagChanged(int tag, bool isdelete);
 };
 
@@ -1195,7 +1195,7 @@ public:
 
 public:
 	bool iterate(FpButtonIterate fp);
-signals:
+Q_SIGNALS:
 
 	/**
 	 * @brief 参考QToolBar::actionTriggered的信号
@@ -1246,7 +1246,7 @@ protected:
 	//    void mouseReleaseEvent(QMouseEvent *e);
 	void hideEvent(QHideEvent* e) Q_DECL_OVERRIDE;
 	virtual void resizeEvent(QResizeEvent* e) Q_DECL_OVERRIDE;
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief hidWindow
 	 */
@@ -1840,7 +1840,7 @@ public:
 	QSize toolButtonIconSize() const;
 	// 此函数会遍历SARibbonPannel下的所有RibbonToolButton，执行函数指针(bool(SARibbonRibbonToolButton*))，函数指针返回false则停止迭代
 	bool iterate(FpRibbonToolButtonIterate fp);
-signals:
+Q_SIGNALS:
 
 	/**
 	 * @brief 等同于QToolBar::actionTriggered
@@ -2004,7 +2004,7 @@ public:
 
 	// 此函数会遍历Category下的所有pannel,执行函数指针，函数指针返回false则停止迭代
 	bool iterate(FpPannelIterate fp);
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief category标题发生了改变信号
 	 * @param n
@@ -2122,7 +2122,7 @@ public:
 	// 设置Category的对齐方式
 	void setCategoryAlignment(SARibbonAlignment al);
 	SARibbonAlignment categoryAlignment() const;
-private slots:
+private Q_SLOTS:
 	void onLeftScrollButtonClicked();
 	void onRightScrollButtonClicked();
 };
@@ -2189,7 +2189,7 @@ public:
 
 	// 判断上下文是否维护了此SARibbonCategory
 	bool isHaveCategory(SARibbonCategory* category) const;
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief 标签加入上下文
 	 * @param category
@@ -2214,7 +2214,7 @@ signals:
 	 * @param title 新名字
 	 */
 	void categoryTitleChanged(SARibbonCategory* category, const QString& title);
-private slots:
+private Q_SLOTS:
 	void onCategoryTitleChanged(const QString& title);
 
 protected:
@@ -2411,10 +2411,10 @@ public:
 	int gridMaximumWidth() const;
 	// 获取SARibbonGalleryGroup管理的actiongroup
 	QActionGroup* actionGroup() const;
-private slots:
+private Q_SLOTS:
 	void onItemClicked(const QModelIndex& index);
 	void onItemEntered(const QModelIndex& index);
-signals:
+Q_SIGNALS:
 	void groupTitleChanged(const QString& title);
 	/**
 	 * @brief 等同QActionGroup的triggered
@@ -2502,7 +2502,7 @@ public:
 public:
 	// 设置最右边三个控制按钮的最大宽度（默认15）
 	static void setGalleryButtonMaximumWidth(int w);
-signals:
+Q_SIGNALS:
 	/**
 	 * @brief 转发管理的SARibbonGalleryGroup::triggered
 	 * 所有加入SARibbonGallery的action都会被一个QActionGroup管理,可以通过@sa getActionGroup 获取到对应的actiongroup
@@ -2516,14 +2516,14 @@ signals:
 	 */
 	void hovered(QAction* action);
 
-public slots:
+public Q_SLOTS:
 	// 上翻页
 	virtual void pageUp();
 	// 下翻页
 	virtual void pageDown();
 	// 显示更多触发，默认弹出内部管理的SARibbonGalleryViewport，用户可重载此函数实现自定义的弹出
 	virtual void showMoreDetail();
-protected slots:
+protected Q_SLOTS:
 	void onItemClicked(const QModelIndex& index);
 	virtual void onTriggered(QAction* action);
 
@@ -2551,7 +2551,7 @@ public:
 	QLabel* titleLabel(QWidget* w);
 	// 移除窗口
 	void removeWidget(QWidget* w);
-public slots:
+public Q_SLOTS:
 	void onTitleChanged(QWidget* w, const QString& title);
 
 private:
@@ -2932,7 +2932,7 @@ public:
 
 	// 设置边角widget可见性，对于mdi窗口，会出现TopLeftCorner和TopRightCorner两个corner widget
 	void setCornerWidgetVisible(bool on, Qt::Corner c = Qt::TopLeftCorner);
-signals:
+Q_SIGNALS:
 
 	/**
 	 @brief 应用按钮点击响应 - 左上角的按钮，通过关联此信号触发应用按钮点击的效果
@@ -2980,7 +2980,7 @@ protected:
 	void updateCategoryTitleToTabName();
 	// 告知WindowButtonGroup的尺寸
 	void setWindowButtonGroupSize(const QSize& s);
-protected slots:
+protected Q_SLOTS:
 	void onWindowTitleChanged(const QString& title);
 	void onWindowIconChanged(const QIcon& i);
 	void onCategoryWindowTitleChanged(const QString& title);
@@ -3425,7 +3425,7 @@ protected:
 	// 删除一个item
 	void removeItem(QStandardItem* item);
 
-private slots:
+private Q_SLOTS:
 	void onComboBoxActionIndexCurrentIndexChanged(int index);
 	void onRadioButtonGroupButtonClicked(QAbstractButton* b);
 	void onPushButtonNewCategoryClicked();
@@ -3664,7 +3664,7 @@ public:
 protected:
 	// 创建ribbonbar的工厂函数
 	SARibbonBar* createRibbonBar();
-private slots:
+private Q_SLOTS:
 	void onPrimaryScreenChanged(QScreen* screen);
 };
 
@@ -3721,7 +3721,7 @@ public:
 	QWidget* widget() const;
 	//
 	QWidget* takeWidget();
-private slots:
+private Q_SLOTS:
 	void onPrimaryScreenChanged(QScreen* screen);
 };
 

--- a/src/SARibbonBar/SARibbonActionsManager.h
+++ b/src/SARibbonBar/SARibbonActionsManager.h
@@ -103,14 +103,14 @@ public:
     //清除
     void clear();
 
-signals:
+Q_SIGNALS:
 
     /**
      * @brief 标签变化触发的信号，变化包括新增和删除
      */
     void actionTagChanged(int tag, bool isdelete);
 
-private slots:
+private Q_SLOTS:
     void onActionDestroyed(QObject* o);
     void onCategoryTitleChanged(const QString& title);
 
@@ -140,7 +140,7 @@ public:
     QAction* indexToAction(QModelIndex index) const;
     void search(const QString& text);
 
-private slots:
+private Q_SLOTS:
     void onActionTagChanged(int tag, bool isdelete);
 };
 

--- a/src/SARibbonBar/SARibbonBar.h
+++ b/src/SARibbonBar/SARibbonBar.h
@@ -368,7 +368,7 @@ public:
 
     // 设置边角widget可见性，对于mdi窗口，会出现TopLeftCorner和TopRightCorner两个corner widget
     void setCornerWidgetVisible(bool on, Qt::Corner c = Qt::TopLeftCorner);
-signals:
+Q_SIGNALS:
 
     /**
      @brief 应用按钮点击响应 - 左上角的按钮，通过关联此信号触发应用按钮点击的效果
@@ -416,7 +416,7 @@ protected:
     void updateCategoryTitleToTabName();
     // 告知WindowButtonGroup的尺寸
     void setWindowButtonGroupSize(const QSize& s);
-protected slots:
+protected Q_SLOTS:
     void onWindowTitleChanged(const QString& title);
     void onWindowIconChanged(const QIcon& i);
     void onCategoryWindowTitleChanged(const QString& title);

--- a/src/SARibbonBar/SARibbonButtonGroupWidget.h
+++ b/src/SARibbonBar/SARibbonButtonGroupWidget.h
@@ -43,7 +43,7 @@ public:
 
 public:
     bool iterate(FpButtonIterate fp);
-signals:
+Q_SIGNALS:
 
     /**
      * @brief 参考QToolBar::actionTriggered的信号

--- a/src/SARibbonBar/SARibbonCategory.h
+++ b/src/SARibbonBar/SARibbonCategory.h
@@ -121,7 +121,7 @@ public:
 
     // 此函数会遍历Category下的所有pannel,执行函数指针，函数指针返回false则停止迭代
     bool iterate(FpPannelIterate fp);
-signals:
+Q_SIGNALS:
     /**
      * @brief category标题发生了改变信号
      * @param n

--- a/src/SARibbonBar/SARibbonCategoryLayout.h
+++ b/src/SARibbonBar/SARibbonCategoryLayout.h
@@ -73,7 +73,7 @@ public:
     // 设置Category的对齐方式
     void setCategoryAlignment(SARibbonAlignment al);
     SARibbonAlignment categoryAlignment() const;
-private slots:
+private Q_SLOTS:
     void onLeftScrollButtonClicked();
     void onRightScrollButtonClicked();
 };

--- a/src/SARibbonBar/SARibbonColorToolButton.h
+++ b/src/SARibbonBar/SARibbonColorToolButton.h
@@ -31,12 +31,12 @@ public:
     ColorStyle colorStyle() const;
     // 建立标准的颜色菜单
     SAColorMenu* setupStandardColorMenu();
-public slots:
+public Q_SLOTS:
     // 设置颜色,会发射colorChanged信号
     void setColor(const QColor& c);
-private slots:
+private Q_SLOTS:
     void onButtonClicked(bool checked = false);
-signals:
+Q_SIGNALS:
     /**
      * @brief 颜色被点击的响应
      * @param color

--- a/src/SARibbonBar/SARibbonContextCategory.h
+++ b/src/SARibbonBar/SARibbonContextCategory.h
@@ -43,7 +43,7 @@ public:
 
     //判断上下文是否维护了此SARibbonCategory
     bool isHaveCategory(SARibbonCategory* category) const;
-signals:
+Q_SIGNALS:
     /**
      * @brief 标签加入上下文
      * @param category
@@ -68,7 +68,7 @@ signals:
      * @param title 新名字
      */
     void categoryTitleChanged(SARibbonCategory* category, const QString& title);
-private slots:
+private Q_SLOTS:
     void onCategoryTitleChanged(const QString& title);
 
 protected:

--- a/src/SARibbonBar/SARibbonCustomizeWidget.h
+++ b/src/SARibbonBar/SARibbonCustomizeWidget.h
@@ -129,7 +129,7 @@ protected:
     //删除一个item
     void removeItem(QStandardItem* item);
 
-private slots:
+private Q_SLOTS:
     void onComboBoxActionIndexCurrentIndexChanged(int index);
     void onRadioButtonGroupButtonClicked(QAbstractButton* b);
     void onPushButtonNewCategoryClicked();

--- a/src/SARibbonBar/SARibbonGallery.h
+++ b/src/SARibbonBar/SARibbonGallery.h
@@ -64,7 +64,7 @@ public:
 public:
     // 设置最右边三个控制按钮的最大宽度（默认15）
     static void setGalleryButtonMaximumWidth(int w);
-signals:
+Q_SIGNALS:
     /**
      * @brief 转发管理的SARibbonGalleryGroup::triggered
      * 所有加入SARibbonGallery的action都会被一个QActionGroup管理,可以通过@sa getActionGroup 获取到对应的actiongroup
@@ -78,14 +78,14 @@ signals:
      */
     void hovered(QAction* action);
 
-public slots:
+public Q_SLOTS:
     // 上翻页
     virtual void pageUp();
     // 下翻页
     virtual void pageDown();
     // 显示更多触发，默认弹出内部管理的SARibbonGalleryViewport，用户可重载此函数实现自定义的弹出
     virtual void showMoreDetail();
-protected slots:
+protected Q_SLOTS:
     void onItemClicked(const QModelIndex& index);
     virtual void onTriggered(QAction* action);
 
@@ -113,7 +113,7 @@ public:
     QLabel* titleLabel(QWidget* w);
     // 移除窗口
     void removeWidget(QWidget* w);
-public slots:
+public Q_SLOTS:
     void onTitleChanged(QWidget* w, const QString& title);
 
 private:

--- a/src/SARibbonBar/SARibbonGalleryGroup.h
+++ b/src/SARibbonBar/SARibbonGalleryGroup.h
@@ -114,10 +114,10 @@ public:
     int gridMaximumWidth() const;
     // 获取SARibbonGalleryGroup管理的actiongroup
     QActionGroup* actionGroup() const;
-private slots:
+private Q_SLOTS:
     void onItemClicked(const QModelIndex& index);
     void onItemEntered(const QModelIndex& index);
-signals:
+Q_SIGNALS:
     void groupTitleChanged(const QString& title);
     /**
      * @brief 等同QActionGroup的triggered

--- a/src/SARibbonBar/SARibbonMainWindow.cpp
+++ b/src/SARibbonBar/SARibbonMainWindow.cpp
@@ -154,7 +154,7 @@ void SARibbonMainWindow::setRibbonBar(SARibbonBar* ribbon)
 void SARibbonMainWindow::setFramelessHitTestVisible(const QWidget* w, bool visible)
 {
 	auto helper = d_ptr->mFramelessHelper;
-	helper->setHitTestVisible(w, visible);
+	helper->setHitTestVisible(const_cast<QWidget*>(w), visible);
 }
 #else
 

--- a/src/SARibbonBar/SARibbonMainWindow.h
+++ b/src/SARibbonBar/SARibbonMainWindow.h
@@ -94,7 +94,7 @@ public:
 protected:
     // 创建ribbonbar的工厂函数
     SARibbonBar* createRibbonBar();
-private slots:
+private Q_SLOTS:
     void onPrimaryScreenChanged(QScreen* screen);
 };
 

--- a/src/SARibbonBar/SARibbonPannel.cpp
+++ b/src/SARibbonBar/SARibbonPannel.cpp
@@ -1002,3 +1002,12 @@ const QList< SARibbonPannelItem* >& SARibbonPannel::ribbonPannelItem() const
 {
     return (pannelLayout()->mItems);
 }
+
+/**
+ * @brief 获取最近添加的按钮
+ * @return 刚才添加的按钮的指针
+ */
+SARibbonToolButton* SARibbonPannel::lastAddActionButton()
+{
+    return d_ptr->lastAddActionButton();
+}

--- a/src/SARibbonBar/SARibbonPannel.h
+++ b/src/SARibbonBar/SARibbonPannel.h
@@ -194,7 +194,11 @@ public:
     QSize toolButtonIconSize() const;
     // 此函数会遍历SARibbonPannel下的所有RibbonToolButton，执行函数指针(bool(SARibbonRibbonToolButton*))，函数指针返回false则停止迭代
     bool iterate(FpRibbonToolButtonIterate fp);
-signals:
+    
+    // 获取最近添加的按钮
+    SARibbonToolButton* lastAddActionButton();
+    
+Q_SIGNALS:
 
     /**
      * @brief 等同于QToolBar::actionTriggered

--- a/src/SARibbonBar/SARibbonStackedWidget.h
+++ b/src/SARibbonBar/SARibbonStackedWidget.h
@@ -32,7 +32,7 @@ protected:
     //    void mouseReleaseEvent(QMouseEvent *e);
     void hideEvent(QHideEvent* e) Q_DECL_OVERRIDE;
     virtual void resizeEvent(QResizeEvent* e) Q_DECL_OVERRIDE;
-signals:
+Q_SIGNALS:
     /**
      * @brief hidWindow
      */

--- a/src/SARibbonBar/SARibbonSystemButtonBar.h
+++ b/src/SARibbonBar/SARibbonSystemButtonBar.h
@@ -69,7 +69,7 @@ public:
 protected:
     virtual void resizeEvent(QResizeEvent* e) Q_DECL_OVERRIDE;
 
-protected slots:
+protected Q_SLOTS:
     Q_SLOT void closeWindow();
     Q_SLOT void minimizeWindow();
     Q_SLOT void maximizeWindow();

--- a/src/SARibbonBar/SARibbonWidget.h
+++ b/src/SARibbonBar/SARibbonWidget.h
@@ -38,7 +38,7 @@ public:
 	QWidget* widget() const;
     //
     QWidget* takeWidget();
-private slots:
+private Q_SLOTS:
 	void onPrimaryScreenChanged(QScreen* screen);
 };
 

--- a/src/SARibbonBar/colorWidgets/SAColorGridWidget.h
+++ b/src/SARibbonBar/colorWidgets/SAColorGridWidget.h
@@ -62,13 +62,13 @@ public:
     void setRowMinimumHeight(int row, int minSize);
     // 让颜色块左对齐
     void setHorizontalSpacerToRight(bool on = true);
-private slots:
+private Q_SLOTS:
     void onButtonClicked(QAbstractButton* btn);
     void onButtonPressed(QAbstractButton* btn);
     void onButtonReleased(QAbstractButton* btn);
     void onButtonToggled(QAbstractButton* btn, bool on);
 
-signals:
+Q_SIGNALS:
     /**
      * @brief 对于check模式，check的颜色触发的信号
      * @param c

--- a/src/SARibbonBar/colorWidgets/SAColorMenu.h
+++ b/src/SARibbonBar/colorWidgets/SAColorMenu.h
@@ -33,16 +33,16 @@ public:
     void enableNoneColorAction(bool on = true);
     // 获取None Color Action,注意，enableNoneColorAction(true),之后才不是nullptr
     QAction* noneColorAction() const;
-public slots:
+public Q_SLOTS:
     // 这是一个辅助槽函数，为了让用户自定义的其他action也能关联menu，可以调用此槽函数，实现selectedColor信号以及menu的隐藏
     void emitSelectedColor(const QColor& c);
-signals:
+Q_SIGNALS:
     /**
      * @brief 选择了颜色触发的信号
      * @param c
      */
     void selectedColor(const QColor& c);
-private slots:
+private Q_SLOTS:
     void onCustomColorActionTriggered(bool on);
     void onNoneColorActionTriggered(bool on);
 

--- a/src/SARibbonBar/colorWidgets/SAColorPaletteGridWidget.h
+++ b/src/SARibbonBar/colorWidgets/SAColorPaletteGridWidget.h
@@ -27,13 +27,13 @@ public:
     // 设置颜色是否是checkable
     void setColorCheckable(bool on = true);
     bool isColorCheckable() const;
-private slots:
+private Q_SLOTS:
     void onMainColorClicked(const QColor& c);
     void onPaletteColorClicked(const QColor& c);
 
 private:
     void init();
-signals:
+Q_SIGNALS:
     /**
      * @brief 对于check模式，check的颜色触发的信号
      * @param c

--- a/src/SARibbonBar/colorWidgets/SAColorToolButton.h
+++ b/src/SARibbonBar/colorWidgets/SAColorToolButton.h
@@ -71,7 +71,7 @@ public:
     SAColorMenu* colorMenu() const;
     // 建立标准的颜色菜单
     SAColorMenu* createColorMenu();
-public slots:
+public Q_SLOTS:
     // 设置颜色,会发射colorChanged信号
     void setColor(const QColor& c);
 
@@ -87,9 +87,9 @@ protected:
     virtual void paintEvent(QPaintEvent* e) Q_DECL_OVERRIDE;
     virtual void resizeEvent(QResizeEvent* e) Q_DECL_OVERRIDE;
     virtual QSize sizeHint() const Q_DECL_OVERRIDE;
-private slots:
+private Q_SLOTS:
     void onButtonClicked(bool checked = false);
-signals:
+Q_SIGNALS:
     /**
      * @brief 颜色被点击的响应
      * @param color

--- a/src/SARibbonBar/colorWidgets/tst/Widget.h
+++ b/src/SARibbonBar/colorWidgets/tst/Widget.h
@@ -20,7 +20,7 @@ public:
     QColor makeRandColor() const;
     //
     void setColor(const QColor& clr);
-private slots:
+private Q_SLOTS:
     void onGridColorWidgetClicked(const QColor& c);
 
 private:

--- a/src/example/MainWindowExample/mainwindow.h
+++ b/src/example/MainWindowExample/mainwindow.h
@@ -39,7 +39,7 @@ private:
     void createActionsManager();
     QAction* createAction(const QString& text, const QString& iconurl, const QString& objName);
     QAction* createAction(const QString& text, const QString& iconurl);
-private slots:
+private Q_SLOTS:
     void onMenuButtonPopupCheckableTest(bool b);
     void onInstantPopupCheckableTest(bool b);
     void onDelayedPopupCheckableTest(bool b);

--- a/src/example/MdiAreaWindowExample/mdimainwindow.h
+++ b/src/example/MdiAreaWindowExample/mdimainwindow.h
@@ -16,7 +16,7 @@ public:
     explicit MainWindow(QWidget* parent = nullptr);
     ~MainWindow();
 
-private slots:
+private Q_SLOTS:
     void on_actionadd_window_triggered();
 
 private:

--- a/src/example/WidgetWithRibbon/InnerWidget.h
+++ b/src/example/WidgetWithRibbon/InnerWidget.h
@@ -15,7 +15,7 @@ class InnerWidget : public QWidget
 public:
     explicit InnerWidget(QWidget* parent = nullptr);
     ~InnerWidget();
-public slots:
+public Q_SLOTS:
     void appendText(const QString& t);
 
 private:

--- a/src/example/WidgetWithRibbon/RibbonWidget.h
+++ b/src/example/WidgetWithRibbon/RibbonWidget.h
@@ -16,7 +16,7 @@ public:
 private:
 	void buildRibbon(SARibbonBar* bar);
 	QAction* createAction(const QString& text, const QString& iconurl);
-private slots:
+private Q_SLOTS:
 	void onRibbonThemeComboBoxCurrentIndexChanged(int index);
 
 private:


### PR DESCRIPTION
将头文件中所有 `signals:` 改为 `Q_SIGNALS:` <- 为了防止开启 `QT_NO_KEYWORDS` 宏后在别的项目中使用时编译报错
将头文件中所有 `slots:` 改为 `Q_SLOTS:`
SARobbonPannel.h 增加 `SARibbonToolButton* lastAddActionButton()` 函数 
在 `SARibbonMainWindow::setFramelessHitTestVisible` 函数中, 为了适配新版 QWindowKit 的 API 变化, 加了一个 const_cast
`.gitignore` 文件中, 加入 忽略 `compile_commands.json`