### PR TITLE
fix raise category bug due to hide category

### DIFF
--- a/src/SARibbonBar/SARibbonBar.cpp
+++ b/src/SARibbonBar/SARibbonBar.cpp
@@ -1552,10 +1552,12 @@ int SARibbonBar::currentIndex()
  */
 void SARibbonBar::raiseCategory(SARibbonCategory* category)
 {
-	int index = d_ptr->mStackedContainerWidget->indexOf(category);
-
-	if (index >= 0) {
-		setCurrentIndex(index);
+	for (int i = 0; i < d_ptr->mRibbonTabBar->count(); ++i) {
+		_SARibbonTabData p = d_ptr->mRibbonTabBar->tabData(i).value< _SARibbonTabData >();
+		if (p.category == category) {
+			d_ptr->mRibbonTabBar->setCurrentIndex(i);
+			return;
+		}
 	}
 }
 


### PR DESCRIPTION
raiseCategory这个函数在有Category隐藏的时候是会有bug的，因为tabbar和stackwidget的index对不上。
### 我的测试代码
![code](https://github.com/user-attachments/assets/0a1a48a2-45fb-454d-8acb-f7af85144f53)
### 修改之前
![before](https://github.com/user-attachments/assets/d07c7767-048e-4b27-bd9c-74a3a40710b4)
### 修改之后
![after](https://github.com/user-attachments/assets/dea57dd3-d2c2-48de-8765-9d3afd706295)
